### PR TITLE
Working Natively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ npm-debug.log
 # IntelliJ
 *.iml
 /.idea
+
+#Vim swap files
+*.swp

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "tbd",
   "scripts": {
-    "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
+    "start": "nodejs ./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js --recursive ./test",
     "test:watch": "npm run test -- --watch"
   },

--- a/src/components/todo_list.js
+++ b/src/components/todo_list.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import Todo from './Todo'
+import Todo from './todo'
 
 class TodoList extends Component {
 


### PR DESCRIPTION
Hey Chris and Doug,

I was able to get it working natively. Ubuntu's native node uses "nodejs" as the binary, so I had to change the package.json script to reflect. I also had to update the webpack defaults to work with my headless Ubuntu Server VM, so I could access it from the browser. After I did that, it seemed like there was a capitalization error in the React component, so I fixed that too. I think I'm ready to handle the kata now. You can safely ignore this pull request.

-Updated package.json to work with native node on ubuntu
-Updated .gitignore to ignore .swp files created by vim
-Updated todo_list.js to work with todo.js